### PR TITLE
[TRIAL] Unroll links before graphical target

### DIFF
--- a/sparse/usr/bin/droid/droid-misc.sh
+++ b/sparse/usr/bin/droid/droid-misc.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+#Misc setup script
+
+ln -sf /dev/binderfs/* /dev/

--- a/sparse/usr/bin/droid/droid-misc.sh
+++ b/sparse/usr/bin/droid/droid-misc.sh
@@ -1,4 +1,13 @@
 #!/bin/sh
 #Misc setup script
 
-ln -sf /dev/binderfs/* /dev/
+WHICH=/apex/com.android.art/lib/libnativehelper.so
+
+# wait for a file we know its last mounted in linkerconfig
+echo "Waiting for $WHICH to be mounted.."
+while [ ! -f $WHICH ]; do sleep 1; done;
+echo "Waiting for $WHICH done."
+
+# Transform softlinks into real copies where needed
+find /overlays -type l | while read SOFTLINK; do cp -f `readlink $SOFTLINK` $SOFTLINK; done
+

--- a/sparse/usr/lib/systemd/system/droid-misc.service
+++ b/sparse/usr/lib/systemd/system/droid-misc.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Misc setup
+After=local-fs.target
+Before=user@.service
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/droid/droid-misc.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=graphical.target

--- a/sparse/usr/lib/systemd/system/graphical.target.wants/droid-misc.service
+++ b/sparse/usr/lib/systemd/system/graphical.target.wants/droid-misc.service
@@ -1,0 +1,1 @@
+../droid-misc.service


### PR DESCRIPTION
/overlays attempt to transform into actual files.

This *seemed* to work until I had other problems with my SFOS boot, may be unrelated.

For example, lipstick started to spit in journalctl -b the same symbol not found errors, and jouralctl -f doesn't work ('journal stopped'). All these are the reason this is just a PR to keep a track of a line of thought.