### PR TITLE
Add boot fix for eSIM devices

### DIFF
--- a/sparse/usr/lib/systemd/system/multi-user.target.wants/ofono-esim-bootfix.service
+++ b/sparse/usr/lib/systemd/system/multi-user.target.wants/ofono-esim-bootfix.service
@@ -1,0 +1,1 @@
+../ofono-esim-bootfix.service

--- a/sparse/usr/lib/systemd/system/ofono-esim-bootfix.service
+++ b/sparse/usr/lib/systemd/system/ofono-esim-bootfix.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=oFono eSIM boot fix
+After=dbus.service ofono.service
+Wants=ofono.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/libexec/nagara/ofono-esim-bootfix.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/sparse/usr/libexec/nagara/ofono-esim-bootfix.sh
+++ b/sparse/usr/libexec/nagara/ofono-esim-bootfix.sh
@@ -59,7 +59,7 @@ ril1_enabled() {
 has_enabled_profile() {
     [ -x "$LPAC" ] || return 1
 
-    "$LPAC" 2>/dev/null | python3 -c '
+    "$LPAC" profile list 2>/dev/null | python3 -c '
 import json
 import sys
 

--- a/sparse/usr/libexec/nagara/ofono-esim-bootfix.sh
+++ b/sparse/usr/libexec/nagara/ofono-esim-bootfix.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+
+LPAC=/usr/bin/lpac
+GETPROP=/system/bin/getprop
+
+TARGET_MODEMS="array:objpath:/ril_0"
+
+log() {
+    echo "[esim-fix] $*"
+}
+
+#
+# Wait for Android properties to become available
+#
+wait_for_device() {
+    while :; do
+        DEVICE="$($GETPROP ro.product.device 2>/dev/null)"
+
+        if [ -n "$DEVICE" ]; then
+            echo "$DEVICE"
+            return 0
+        fi
+
+        sleep 1
+    done
+}
+
+#
+# Wait until ofono exposes enabled modems
+#
+wait_for_modems() {
+    while :; do
+        OUTPUT="$(dbus-send --system \
+            --print-reply \
+            --dest=org.ofono \
+            / \
+            org.nemomobile.ofono.ModemManager.GetEnabledModems \
+            2>/dev/null)"
+
+        if [ -n "$OUTPUT" ]; then
+            echo "$OUTPUT"
+            return 0
+        fi
+
+        sleep 1
+    done
+}
+
+#
+# Check whether ril_1 is enabled
+#
+ril1_enabled() {
+    echo "$1" | grep -q '"/ril_1"'
+}
+
+#
+# Check if lpac has at least one enabled profile
+#
+has_enabled_profile() {
+    [ -x "$LPAC" ] || return 1
+
+    "$LPAC" 2>/dev/null | python3 -c '
+import json
+import sys
+
+try:
+    data = json.load(sys.stdin)
+
+    profiles = data.get("payload", {}).get("data", [])
+
+    for p in profiles:
+        if p.get("profileState") == "enabled":
+            sys.exit(0)
+
+except Exception:
+    pass
+
+sys.exit(1)
+'
+}
+
+##############################################################################
+
+DEVICE="$(wait_for_device)"
+
+case "$DEVICE" in
+    XQ-CT54|XQ-CQ54)
+        log "special boot handling required for $DEVICE"
+        ;;
+    *)
+        log "device $DEVICE does not require special handling"
+        exit 0
+        ;;
+esac
+
+MODEMS="$(wait_for_modems)"
+
+if ! ril1_enabled "$MODEMS"; then
+    log "ril_1 is not enabled, nothing to do"
+    exit 0
+fi
+
+log "ril_1 is enabled"
+
+if has_enabled_profile; then
+    log "enabled eSIM profile found, nothing to do"
+    exit 0
+fi
+
+log "no enabled eSIM profiles found"
+log "disabling ril_1 and restarting ofono"
+
+dbus-send --system \
+    --print-reply \
+    --dest=org.ofono \
+    / \
+    org.nemomobile.ofono.ModemManager.SetEnabledModems \
+    $TARGET_MODEMS \
+    >/dev/null 2>&1
+
+systemctl restart ofono
+
+exit 0


### PR DESCRIPTION
This does require lpac installed from Chum. Chum version together with Nagara config (/etc/lpac) allows to use /usr/bin/lpac directly - without any extra scripts.

@b100dian - please check if it works for you. It should chek whether you have eSIM profile active and, if detected, keep ofono config as it is.

Here is output for me - no eSIM profiles and booting with the both SIM cards activated:

```
[root@Xperia1IV defaultuser]# systemctl status ofono-esim-bootfix
● ofono-esim-bootfix.service - oFono eSIM boot fix
   Loaded: loaded (/usr/lib/systemd/system/ofono-esim-bootfix.service; disabled; vendor preset: enabled)
   Active: active (exited) since Sun 2026-05-24 21:44:34 EEST; 1min 13s ago
  Process: 4576 ExecStart=/usr/libexec/nagara/ofono-esim-bootfix.sh (code=exited, status=0/SUCCESS)
 Main PID: 4576 (code=exited, status=0/SUCCESS)

May 24 21:44:34 Xperia1IV systemd[1]: Starting oFono eSIM boot fix...
May 24 21:44:34 Xperia1IV ofono-esim-bootfix.sh[4576]: [esim-fix] special boot handling required for XQ-CT54
May 24 21:44:34 Xperia1IV ofono-esim-bootfix.sh[4576]: [esim-fix] ril_1 is enabled
May 24 21:44:34 Xperia1IV ofono-esim-bootfix.sh[4576]: [esim-fix] no enabled eSIM profiles found
May 24 21:44:34 Xperia1IV ofono-esim-bootfix.sh[4576]: [esim-fix] disabling ril_1 and restarting ofono
May 24 21:44:34 Xperia1IV systemd[1]: Started oFono eSIM boot fix.
```